### PR TITLE
Install PostgreSQL for macOS in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,6 @@ jobs:
     steps:
       # Start preinstalled PostgreSQL database on Windows, macOS and Linux
       # https://github.com/karlhorky/github-tricks/#github-actions-start-preinstalled-postgresql-database-on-windows-macos-and-linux
-      - name: Install PostgreSQL on macOS
-        shell: bash
-        if: runner.os == 'macOS'
-        run: |
-          brew install postgresql
       - name: Add PostgreSQL binaries to PATH
         shell: bash
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,11 @@ jobs:
       PGUSERNAME: preflight_test_project_next_js_passing
       PGPASSWORD: preflight_test_project_next_js_passing
     steps:
-      # Start preinstalled PostgreSQL database on Windows, macOS and Linux
-      # https://github.com/karlhorky/github-tricks/#github-actions-start-preinstalled-postgresql-database-on-windows-macos-and-linux
+      # Create PostgreSQL databases on Windows, macOS and Linux
+      # https://github.com/karlhorky/github-tricks/#github-actions-create-postgresql-databases-on-windows-macos-and-linux
+      - name: Install PostgreSQL on macOS
+        if: runner.os == 'macOS'
+        run: brew install postgresql
       - name: Add PostgreSQL binaries to PATH
         shell: bash
         run: |


### PR DESCRIPTION
In the GH Actions file, we are using binaries for all platforms with PostgreSQL, but macOS doesn't have PostgreSQL in the binary. This PR adds a step to the workflow file to install PostgreSQL for macOS. Without installing PostgreSQL, the CI fails with 
```
/Users/runner/work/_temp/a080ce3a-0e79-4952-b50c-52bcbb8ad477.sh: line 11: initdb: command not found
Error: Process completed with exit code 127.
```

I looked at the list of [macOS 14 runner images installed software](https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md), PostgreSQL is not on the list. 

A lot of issues can be found on GH about this issue with macOS 
- https://github.com/actions/runner-images/issues/9029
- https://github.com/actions/runner-images/issues/9083
- https://github.com/ikalnytskyi/action-setup-postgres/issues/16

This is the [answer](https://github.com/actions/runner-images/issues/9029#issuecomment-1856487621) of the GH Actions Team Member before closing the issues 
> Hello! We would not like to pre-install databases to arm64 images due to maintenance concerns and also pretty low demand on macOS specifically.







