### PR TITLE
Prevent PostgreSQL start from hanging by logging output to a file

### DIFF
--- a/scripts/alpine-postgresql-setup-and-start.sh
+++ b/scripts/alpine-postgresql-setup-and-start.sh
@@ -9,8 +9,10 @@ echo "Setting up PostgreSQL on Alpine Linux..."
 export PGDATA=/var/lib/postgresql/data
 mkdir "$PGDATA"
 
-# If the project has more environment variables then PGHOST, PGDATABASE, PGUSERNAME and PGPASSWORD, add them to the Array below
-# e.g. echo '[ "CLOUDINARY_API_KEY", "CLOUDINARY_API_SECRET" ]'
+# If the project has more environment variables than
+# PGHOST, PGDATABASE, PGUSERNAME and PGPASSWORD, add
+# strings of their names to the array below, eg:
+# echo '[ "CLOUDINARY_API_KEY", "CLOUDINARY_API_SECRET" ]'
 echo "PREFLIGHT_ENVIRONMENT_VARIABLES:"
 echo '[]'
 

--- a/scripts/alpine-postgresql-setup-and-start.sh
+++ b/scripts/alpine-postgresql-setup-and-start.sh
@@ -9,6 +9,11 @@ echo "Setting up PostgreSQL on Alpine Linux..."
 export PGDATA=/var/lib/postgresql/data
 mkdir "$PGDATA"
 
+# If the project has more environment variables then PGHOST, PGDATABASE, PGUSERNAME and PGPASSWORD, add them to the Array below
+# e.g. echo '[ "CLOUDINARY_API_KEY", "CLOUDINARY_API_SECRET" ]'
+echo "PREFLIGHT_ENVIRONMENT_VARIABLES:"
+echo '[]'
+
 # Only allow postgres user access to data directory
 chmod 0700 "$PGDATA"
 

--- a/scripts/alpine-postgresql-setup-and-start.sh
+++ b/scripts/alpine-postgresql-setup-and-start.sh
@@ -19,7 +19,9 @@ initdb -D "$PGDATA"
 sed "/^[# ]*log_destination/clog_destination = 'syslog'" -i "$PGDATA/postgresql.conf"
 
 echo "Starting PostgreSQL..."
-pg_ctl start -D "$PGDATA"
+pg_ctl start --pgdata="$PGDATA" --log="/tmp/postgresql-server-start.log"
+sleep 1
+cat "/tmp/postgresql-server-start.log"
 
 echo "Creating database, user and schema..."
 psql -U postgres postgres << SQL


### PR DESCRIPTION
Redirect `pg_ctl start` logs to a file instead of `stdout` to avoid hanging, as discussed in [sindresorhus/execa#1191](https://github.com/sindresorhus/execa/issues/1191). Added a sleep 1 to ensure logs are written before reading them with cat.